### PR TITLE
no longer returning null when lambda is executed

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,11 @@ exports.handler = (event, context) => {
       .then( (policy) => {
         console.log('Success: Policy is '
             + JSON.stringify(policy));
+          context.succeed(policy);
       } )
       .catch((error) => {
         console.log('Error: error is '
             + JSON.stringify(error));
+          context.fail(error);
       });
 };


### PR DESCRIPTION
added 2 lines of code (lines 13 & 18) to the index.js so that the policies were actually returned by the handler. 

context.succeed(policy) & context.fail(policy)

resolves #1
