### PR TITLE
2019 02 10 security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "nock": "10.0.6",
     "sinon": "^1.17.5",
     "testdouble": "^1.6.1",
-    "eslint": "5.12.1",
+    "eslint": "2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.9.2",
     "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
-    "lodash": "4.17.9",
+    "lodash": "4.17.11",
     "lambda-tester": "^2.6.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "mocha": "^5.1.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
-    "nock": "^8.0.0",
+    "nock": "10.0.6",
     "sinon": "^1.17.5",
     "testdouble": "^1.6.1",
-    "eslint": "^2.13.1",
+    "eslint": "5.12.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.9.2",
     "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
+    "lodash": "4.17.9",
     "lambda-tester": "^2.6.0"
   },
   "scripts": {


### PR DESCRIPTION
upgrade nock to fix failing FB test, revert attempt to upgrade eslint since it alters linting params, and add a forced dependency on lodash 4.17.11 to resolve security vulnerability....